### PR TITLE
Changing the Init Container (download-fluentd-conf-on-persistent-volume) to use CURL instead of WGET

### DIFF
--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -9,7 +9,7 @@ artifactory:
         - '-c'
         - >
           mkdir -p {{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/;
-          wget https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.rt -O {{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/fluentd.conf
+          curl https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.rt -O {{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/fluentd.conf
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"
           name: volume

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -9,7 +9,7 @@ artifactory:
         - '-c'
         - >
           mkdir -p {{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/;
-          wget https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.rt -O {{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/fluentd.conf
+          curl https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.rt -O {{ .Values.artifactory.persistence.mountPath }}/etc/fluentd/fluentd.conf
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"
           name: artifactory-volume

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -22,7 +22,7 @@ common:
         - '-c'
         - >
           mkdir -p {{ .Values.xray.persistence.mountPath }}/etc/fluentd/;
-          wget https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.xray -O {{ .Values.xray.persistence.mountPath }}/etc/fluentd/fluentd.conf
+          curl https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.xray -O {{ .Values.xray.persistence.mountPath }}/etc/fluentd/fluentd.conf
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"
           name: data-volume


### PR DESCRIPTION
Changing the Init Container (download-fluentd-conf-on-persistent-volume) to use CURL instead of WGET
Follow https://git.jfrog.info/projects/JFROG/repos/artifactory/pull-requests/7564/overview for more details on the issue.