### PR TITLE
Upgrade fluentd side car image to resolve existing CVEs 

### DIFF
--- a/.github/workflows/slack-notify-issues.yml
+++ b/.github/workflows/slack-notify-issues.yml
@@ -15,6 +15,6 @@ jobs:
           SLACK_COLOR: '#00A86B'
           SLACK_ICON: https://pbs.twimg.com/profile_images/978188446178082817/86ulJdF0.jpg
           SLACK_TITLE: "[${{ github.event.issue.state}}] ${{ github.event.issue.title }} on ${{ github.repository }} :rocket:"
-          SLACK_MESSAGE: 'Link: ${{ github.event.issue.url }}'
+          SLACK_MESSAGE: 'Link: ${{ github.event.issue.html_url }}'
           SLACK_USERNAME: PartnerEngineers
           SLACK_WEBHOOK: ${{ secrets.SLACK_ISSUE_WEBHOOK }}

--- a/.jfrog-pipelines/pipelines.yml
+++ b/.jfrog-pipelines/pipelines.yml
@@ -1,0 +1,46 @@
+resources:
+  - name: partnership_git_repo
+    type: GitRepo
+    configuration:
+      gitProvider: partnership_github
+      path: jfrog/log-analytics-splunk
+      branches:
+        include: ^gitBranch$
+
+  - name: image_res
+    type: Image
+    configuration:
+      autoPull: false
+      sourceRepository: pts-observability
+      registry: PartnershipArtifactory
+      imageName: partnership-pts-observability.jfrog.io/fluentd
+      imageTag: '4.1'
+
+pipelines:
+  - name: dockerbuild_fluentd
+    configuration:
+      jfrogCliVersion: 2
+    steps:
+      - name: docker_build
+        type: DockerBuild
+        configuration:
+          affinityGroup: DockerBuildAndPush
+          dockerFileLocation: fluentd-installer
+          dockerFileName: Dockerfile.fluentd.sidecar
+          dockerImageName: partnership-pts-observability.jfrog.io/fluentd
+          dockerImageTag: '4.1'
+          inputResources:
+            - name: partnership_git_repo
+          integrations:
+            - name: PartnershipArtifactory
+
+      - name: docker_push
+        type: DockerPush
+        configuration:
+          affinityGroup: DockerBuildAndPush
+          integrations:
+            - name: PartnershipArtifactory
+          inputSteps:
+            - name: docker_build
+          outputResources:
+            - name: image_res

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,78 +1,105 @@
 # JFrog Log Analytics Changelog
+
 All changes to the log analytics integration will be documented in this file.
 
+## [1.0.1] - March 22nd, 2024
+
+* Updated docker images to use fluetnd:1.16.3 to resolve existing CVEs. Please see [security section](https://github.com/jfrog/log-analytics-splunk/security) for more info
+* Added CI to generate [fluentd side car docker](https://github.com/jfrog/log-analytics-splunk/blob/master/fluentd-installer/Dockerfile.fluentd.sidecar) image from source
+
 ## [1.0.0] - May 26th, 2023
+
 * Supporting only OS/VM, Docker and k8s installation types
 * Adding .env files instead of setting/filling variables in fluentd config
 * Adding jfrog and heap callhome in fluentd config
 * Supporting only Artifactory and Xray Fluentd config
 
 ## [0.13.0] - Feb 14, 2022
+
 * Added call home implementation to the artifactory fluent configuration
 
 ## [0.12.0] - May 26, 2021
+
 ### Breaking Changes
+
 * Using unified fluentd configuration for Xray Logs and Violations dashboards
 * Using APIKey to authenticate Xray Violations (SIEM fluentd input plugin)
 * Sending Xray logs and violation data to the same index
 * Using log_source to filter in Xray Violations dashboard queries
 
 ## [0.11.2] - Apr 12, 2021
+
 * Fixing violation data correlation with user, ip information
 
 ## [0.11.2] - Apr 5, 2021
+
 * Fixing bugs in Dockerhub widgets, Xray Violations Dashboard
 
 ## [0.11.1] - Mar 30, 2021
+
 * Renaming widgets, fixing search queries in Xray Violations Dashboard
 
 ## [0.11.0] - Mar 3, 2021
+
 * Adding Violations widgets to Xray dashboard
 
 ## [0.10.0] - Feb 17, 2021
+
 * Normalizing access, request logs
 * Added eventtypes, tags, fields, macros to the app
 
 ## [0.9.2] - Feb 3, 2021
+
 * New Widgets to Xray tab to show vulnerability information
 
 ## [0.9.1] - Jan 28, 2021
+
 * Helm support for Splunk to deploy Artifactory or Xray via helm with logs sent to Splunk
 
 ## [0.9.0] - Dec 1, 2020
+
 * Log Volume charts to show only artifactory and xray logs respectively
 * Adding macro to avoid index dependency
 
 ## [0.8.0] - Oct 20, 2020
+
 * README updates for new Dockerhub / Docker widgets in Splunkbase app
 * Added CHANGELOG-splunkbase.md to mirror release notes in Splunkbase
 
 ## [0.7.0] - Oct 20, 2020
+
 * Fixing issue with ip_address in access logs having space and . at the end
 
 ## [0.6.0] - Sept 25, 2020
+
 * [BREAKING] Splunk fluentd configs updated to use JF_PRODUCT_DATA_INTERNAL env.
 
 ## [0.5.1] - Sept 9, 2020
+
 * Splunk repo now submodule of parent log-analytics.
 
 ## [0.5.0] - Sept 8, 2020
+
 * Adding JFrog Pipelines fluent configuration files to capture logs
 
 ## [0.4.0] - Sept 4, 2020
+
 * Adding JFrog Mission Control fluent configuration files to capture logs
 
 ## [0.3.0] - Aug 26, 2020
+
 * Adding JFrog Distribution fluent configuration files to capture logs
 
 ## [0.2.0] - Aug 24, 2020
+
 * Splunk updates to launch new version of Splunkbase app v1.1.0
 
 ## [0.1.1] - June 1, 2020
+
 * Removing the need for user to specify splunk host , user, and token twice
 * Fixing issue with regex on the audit security log
 * Fixed issue with the repo and image when not docker api url
 
 ## [0.1.0] - May 12, 2020
-* Initial release of Jfrog Logs Analytic integration
 
+* Initial release of Jfrog Logs Analytic integration

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+
+
+| Version  | Supported |
+| -------- | --------- |
+| 1.0.x    | ✅        |
+| <= 1.0.x | ❌        |
+
+## Reporting a Vulnerability
+
+Please post your vulnerability report from the following page:
+https://github.com/jfrog/log-analytics-splunk/security/advisories
+
+## Fixed issues
+
+#### March 22, 2024
+
+Upgraded docker images to use fluentd:1.16.3
+This resolves the following CVEs
+
+* [CVE-2023-4911](https://github.com/advisories/GHSA-m77w-6vjw-wh2f "CVE-2023-4911")
+* [CVE-2019-8457](https://github.com/advisories/GHSA-p4jx-5p2x-4pq7)
+
+Note: When scanning our fluentd docker image `releases-pts-observability-fluentd.jfrog.io/fluentd:4.1` for volunerabilities, [CVE-2023-45853](https://www.cve.org/CVERecord?id=CVE-2023-45853) still comes up (from fluentd:1.16.3). However, fluentd claims it's a [non-issue](https://github.com/fluent/fluentd-kubernetes-daemonset/issues/1464#:~:text=zlib%3A%20CVE,not%20built%2Din.) since affected code (MiniZip) is not built-in

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for bitnami/fluentd sidecar image with all the necessary plugins for our log analytic providers
-FROM bitnami/fluentd:1.15.2
+FROM bitnami/fluentd:1.16.3
 LABEL maintainer="Partner Engineering <partner_support@jfrog.com>"
 
 ## Build time Arguments, short circuit them to ENV Variables so they are available at run time also

--- a/fluentd-installer/Dockerfile.fluentd.sidecar
+++ b/fluentd-installer/Dockerfile.fluentd.sidecar
@@ -1,25 +1,23 @@
 # Dockerfile for bitnami/fluentd sidecar image with all the necessary plugins for our log analytic providers
-FROM bitnami/fluentd:1.15.2
+FROM bitnami/fluentd:1.16.3
 LABEL maintainer "Partner Engineering <partner_support@jfrog.com>"
 
 USER root
 
 ##Uninstall elastic plugin which is preinstalled in bitnami fluentd
 ##Pin elastic gem version to 7.14
-RUN fluent-gem uninstall elasticsearch -a --ignore-dependencies
-RUN fluent-gem install elasticsearch -v 7.14 --no-document
-## Install custom Fluentd plugins
-RUN fluent-gem install fluent-plugin-jfrog-siem --no-document
-RUN fluent-gem install fluent-plugin-splunk-hec --no-document
-RUN fluent-gem install fluent-plugin-datadog --no-document
-RUN fluent-gem install fluent-plugin-elasticsearch --no-document
-RUN fluent-gem install fluent-plugin-record-modifier --no-document
-RUN fluent-gem install fluent-plugin-jfrog-metrics --no-document
-RUN fluent-gem install fluent-plugin-jfrog-send-metrics --no-document
-RUN fluent-gem install fluent-plugin-newrelic --no-document
-RUN fluent-gem install fluent-plugin-concat --no-document
-RUN fluent-gem uninstall concurrent-ruby -v '>1.1.9'
-
-
+RUN fluent-gem uninstall elasticsearch -a --ignore-dependencies \
+  && fluent-gem install elasticsearch -v 7.14 --no-document \
+  ## Install custom Fluentd plugins
+  && fluent-gem install fluent-plugin-jfrog-siem --no-document \
+  && fluent-gem install fluent-plugin-splunk-hec --no-document \
+  && fluent-gem install fluent-plugin-datadog --no-document \
+  && fluent-gem install fluent-plugin-elasticsearch --no-document \
+  && fluent-gem install fluent-plugin-record-modifier --no-document \
+  && fluent-gem install fluent-plugin-jfrog-metrics --no-document \
+  && fluent-gem install fluent-plugin-jfrog-send-metrics --no-document \
+  && fluent-gem install fluent-plugin-newrelic --no-document \
+  && fluent-gem install fluent-plugin-concat --no-document \
+  && fluent-gem uninstall concurrent-ruby -v '>1.1.9'
 
 USER 1001

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -15,7 +15,7 @@ artifactory:
           name: volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.0"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.1"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -1,4 +1,4 @@
-installerInfo: '{ "productId": "OnPremObservability-Splunk/1.0.0", "features": [ { "featureId": "ArtifactoryVersion/{{ default .Chart.AppVersion .Values.artifactory.image.version }}" }, { "featureId": "{{ if .Values.postgresql.enabled }}postgresql{{ else }}{{ .Values.database.type }}{{ end }}/0.0.0" }, { "featureId": "Platform/{{ default "kubernetes" .Values.installer.platform }}" },  { "featureId": "Channel/OnPremObservability-Splunk-Helm" } ] }'
+installerInfo: '{ "productId": "OnPremObservability-Splunk/1.0.1", "features": [ { "featureId": "ArtifactoryVersion/{{ default .Chart.AppVersion .Values.artifactory.image.version }}" }, { "featureId": "{{ if .Values.postgresql.enabled }}postgresql{{ else }}{{ .Values.database.type }}{{ end }}/0.0.0" }, { "featureId": "Platform/{{ default "kubernetes" .Values.installer.platform }}" },  { "featureId": "Channel/OnPremObservability-Splunk-Helm" } ] }'
 artifactory:
   customInitContainersBegin: |
     - name: "prepare-fluentd-conf-on-persistent-volume"

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -15,7 +15,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.0"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.1"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -1,4 +1,4 @@
-installerInfo: '{ "productId": "OnPremObservability-Splunk/1.0.0", "features": [ { "featureId": "ArtifactoryVersion/{{ default .Chart.AppVersion .Values.artifactory.image.version }}" }, { "featureId": "{{ if .Values.postgresql.enabled }}postgresql{{ else }}{{ .Values.database.type }}{{ end }}/0.0.0" }, { "featureId": "Platform/{{ default "kubernetes" .Values.installer.platform }}" },  { "featureId": "Channel/OnPremObservability-Splunk-Helm" } ] }'
+installerInfo: '{ "productId": "OnPremObservability-Splunk/1.0.1", "features": [ { "featureId": "ArtifactoryVersion/{{ default .Chart.AppVersion .Values.artifactory.image.version }}" }, { "featureId": "{{ if .Values.postgresql.enabled }}postgresql{{ else }}{{ .Values.database.type }}{{ end }}/0.0.0" }, { "featureId": "Platform/{{ default "kubernetes" .Values.installer.platform }}" },  { "featureId": "Channel/OnPremObservability-Splunk-Helm" } ] }'
 artifactory:
   customInitContainersBegin: |
     - name: "prepare-fluentd-conf-on-persistent-volume"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -19,7 +19,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.0"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.1"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
* Upgrade fluentd side car image to use bitnami/fluentd:1.16.3 in order to resolve existing CVEs 
* Added Pipelines CI to auto-generate the fluentd side car image
* Added security logs