### PR TITLE
PTRENG-6768 - Upgrade FluentD to 1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes to the log analytics integration will be documented in this file.
 
+## [1.0.11] - January 2, 2025
+
+* FluentD sidecar image version bumped to 4.15, to upgrade base image to bitnami/fluentd 1.18.0
+
 # [1.0.10] - December 10, 2024
 
 * Upgrade Splunk App to version 1.2.8. Changes are available [here](./CHANGELOG-splunkbase.md)

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.14"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.15"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.14"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.15"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -19,7 +19,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.14"
+      image: "releases-pts-observability-fluentd.jfrog.io/fluentd:4.15"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
* FluentD sidecar image version bumped to 4.15, to upgrade base image to bitnami/fluentd 1.18.0
* Resolving CVE-2024-2193 by upgrading to bitnami/fluentd 1.18.0