### PR TITLE
JOBS-2089: Add RTFS metrics source in log-analytics-splunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All changes to the log analytics integration will be documented in this file.
 
 ## [1.0.14] - April 2026
 
-* Added RTFS (Real-Time File Store) metrics collection support in Artifactory fluentd config (JOBS-1897)
+* Added RTFS (JFrog Artifactory Federation Service) metrics collection support in Artifactory fluentd config (JOBS-1897)
 * Requires fluent-plugin-jfrog-metrics >= 0.2.16
 
 ## [1.0.13] - April 22, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All changes to the log analytics integration will be documented in this file.
 
+## [1.0.14] - April 2026
+
+* Added RTFS (Real-Time File Store) metrics collection support in Artifactory fluentd config (JOBS-1897)
+* Requires fluent-plugin-jfrog-metrics >= 0.2.16
+
 ## [1.0.13] - April 22, 2025
 
 * Upgrade Splunk App to version 1.2.9. Changes are available [here](./CHANGELOG-splunkbase.md)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Once this configuration is done and the application is restarted, metrics will b
 
 :bulb: Metrics are enabled by default in Xray.
 
-:bulb: **RTFS Metrics**: If your Artifactory deployment includes RTFS (Real-Time File Store), metrics are automatically collected from the `artifactory/service/rtfs/api/v1/metrics` endpoint. No additional configuration is required -- the fluentd config already includes an RTFS metrics source block that runs alongside the standard Artifactory metrics collection. Requires `fluent-plugin-jfrog-metrics` >= 0.2.16.
+:bulb: **RTFS Metrics**: If your Artifactory deployment includes RTFS (JFrog Artifactory Federation Service), metrics are automatically collected from the `rtfs/api/v1/metrics` endpoint. No additional configuration is required -- the fluentd config already includes an RTFS metrics source block that runs alongside the standard Artifactory metrics collection. Requires `fluent-plugin-jfrog-metrics` >= 0.2.16.
 
 For Kubernetes-based installations, openMetrics is enabled in the helm install commands listed below
 
@@ -550,7 +550,7 @@ JFrog Artifactory Dashboard is divided into multiple sections Application, Audit
 
 #### JFrog RTFS Metrics
 
-When RTFS is deployed as part of Artifactory, RTFS metrics are collected from `artifactory/service/rtfs/api/v1/metrics` and forwarded to Splunk with the `jfrog.rtfs` metric prefix. These metrics are available alongside standard Artifactory metrics in Splunk for monitoring RTFS-specific performance and health.
+When RTFS is deployed as part of Artifactory, RTFS metrics are collected from `rtfs/api/v1/metrics` and forwarded to Splunk with the `jfrog.rtfs` metric prefix. These metrics are available alongside standard Artifactory metrics in Splunk for monitoring RTFS-specific performance and health.
 
 ### Xray dashboard
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,10 @@ artifactory:
 
 Once this configuration is done and the application is restarted, metrics will be available in Open Metrics Format
 
-Metrics are enabled by default in Xray.
+:bulb: Metrics are enabled by default in Xray.
+
+:bulb: **RTFS Metrics**: If your Artifactory deployment includes RTFS (Real-Time File Store), metrics are automatically collected from the `artifactory/service/rtfs/api/v1/metrics` endpoint. No additional configuration is required -- the fluentd config already includes an RTFS metrics source block that runs alongside the standard Artifactory metrics collection. Requires `fluent-plugin-jfrog-metrics` >= 0.2.16.
+
 For Kubernetes-based installations, openMetrics is enabled in the helm install commands listed below
 
 ## Fluentd Installation
@@ -544,6 +547,10 @@ JFrog Artifactory Dashboard is divided into multiple sections Application, Audit
 * **System Metrics** - This section tracks CPU Usage, System Memory and Disk Usage metrics
 * **Heap Metrics** - This section tracks Heap Memory and Garbage Collection
 * **Connection Metrics** - This section tracks Database connections and HTTP Connections
+
+#### JFrog RTFS Metrics
+
+When RTFS is deployed as part of Artifactory, RTFS metrics are collected from `artifactory/service/rtfs/api/v1/metrics` and forwarded to Splunk with the `jfrog.rtfs` metric prefix. These metrics are available alongside standard Artifactory metrics in Splunk for monitoring RTFS-specific performance and health.
 
 ### Xray dashboard
 

--- a/fluent.conf.rt
+++ b/fluent.conf.rt
@@ -9,6 +9,24 @@
   username "#{ENV['JPD_ADMIN_USERNAME']}"
   token "#{ENV['JFROG_ADMIN_TOKEN']}"
   common_jpd "#{ENV['COMMON_JPD']}"
+  target_platform "SPLUNK"
+  # @log_level debug
+  # request_timeout 30s
+  # verify_ssl "#{ENV['SPLUNK_VERIFY_SSL']}"
+</source>
+# JFROG RTFS METRICS SOURCE
+# Requires fluent-plugin-jfrog-metrics >= 0.2.16 and RTFS enabled in the Artifactory deployment
+<source>
+  @type jfrog_metrics
+  @id metrics_http_rtfs
+  tag jfrog.metrics.rtfs
+  execution_interval 60s
+  metric_prefix 'jfrog.rtfs'
+  jpd_url "#{ENV['JPD_URL']}"
+  username "#{ENV['JPD_ADMIN_USERNAME']}"
+  token "#{ENV['JFROG_ADMIN_TOKEN']}"
+  common_jpd "#{ENV['COMMON_JPD']}"
+  target_platform "SPLUNK"
   # @log_level debug
   # request_timeout 30s
   # verify_ssl "#{ENV['SPLUNK_VERIFY_SSL']}"


### PR DESCRIPTION
Add RTFS (Real-Time File Store) metrics collection support to the Artifactory fluentd config for Splunk. This enables scraping metrics from the RTFS endpoint at artifactory/service/rtfs/api/v1/metrics and forwarding them to Splunk with the jfrog.rtfs metric prefix.

Changes:
- Add RTFS source block in fluent.conf.rt with target_platform SPLUNK
- Add explicit target_platform to existing Artifactory source block
- Update README with RTFS metrics documentation
- Update CHANGELOG with new version entry

Requires fluent-plugin-jfrog-metrics >= 0.2.16
Parent ticket: JOBS-1897

Testing Done:
**Container**: `jfrog-fluentd-splunk-rt` + `splunk-test` (local Splunk Enterprise)
**Fluentd logs**:
```
[info]: [metrics_http_jfrt] Executing jfrog.rtfs metrics collection from: http://host.docker.internal:8082/rtfs/api/v1/metrics
[info]: [metrics_http_jfrt] jfrog.rtfs metrics were successfully collected from url: http://host.docker.internal:8082/rtfs/api/v1/metrics
[info]: [metrics_http_jfrt] Timer task Execution successfully returned
```
**Splunk mstats query**:
```
| mstats latest(_value) as value WHERE index="jfrog_splunk_metrics" AND metric_name="jfrog.rtfs.*" BY metric_name
```
**Result**: 148 unique RTFS metrics. Sample:
| metric_name | value |
|---|---|
| jfrog.rtfs.application_ready_time_seconds | 18.218 |
| jfrog.rtfs.application_started_time_seconds | 5.931 |
| jfrog.rtfs.disk_free_bytes | 864835551232 |
| jfrog.rtfs.disk_total_bytes | 977896124416 |
| jfrog.rtfs.executor_active_threads | 0 |
| jfrog.rtfs.grpc_server_received_total | 2 |
| jfrog.rtfs.hikaricp_connections | 3 |

UI:
<img width="1728" height="1038" alt="Screenshot 2026-04-22 at 4 44 44 PM" src="https://github.com/user-attachments/assets/6f8a4ee8-6238-45de-b51f-a4cbe4d1e531" />
