### PR TITLE
JOBS-2480: Bump fluentd sidecar image to 4.20 (Helm values)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All changes to the log analytics integration will be documented in this file.
 
+## [1.0.16] - June 2026
+
+* Fluentd sidecar image bumped to 4.20: migrated to Echo secure base (fluentd 1.19.2, Debian 13), remediating Critical/High CVEs in 4.19 (JOBS-2475)
+* Pinned fluent-plugin-jfrog-metrics ~> 0.2.17
+
 ## [1.0.15] - April 2026
 
 * Fix incorrect field name in access-security-audit log parsing: renamed `token_id` capture group to `trace_id` to match the actual log format documented at https://docs.jfrog.com/administration/docs/audit-trail-log (JOBS-2031)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All changes to the log analytics integration will be documented in this file.
 ## [1.0.16] - June 2026
 
 * Fluentd sidecar image bumped to 4.20: migrated to Echo secure base (fluentd 1.19.2, Debian 13), remediating Critical/High CVEs in 4.19 (JOBS-2475)
-* Pinned fluent-plugin-jfrog-metrics ~> 0.2.17
 
 ## [1.0.15] - April 2026
 

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
 RUN fluent-gem install fluent-plugin-concat && \
     fluent-gem install fluent-plugin-splunk-hec && \
     fluent-gem install fluent-plugin-jfrog-siem && \
-    fluent-gem install fluent-plugin-jfrog-metrics -v '~> 0.2.17' && \
+    fluent-gem install fluent-plugin-jfrog-metrics && \
     fluent-gem install fluent-plugin-jfrog-send-metrics
 
 ## Download Config Files

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,5 +1,5 @@
-# Dockerfile for bitnami/fluentd sidecar image with all the necessary plugins for our log analytic providers
-FROM bitnami/fluentd:1.18.0
+# Dockerfile for fluentd sidecar image with all the necessary plugins for our log analytic providers
+FROM reg.echohq.com/fluentd:1.19.2
 LABEL maintainer="Partner Engineering <partner_support@jfrog.com>"
 
 ## Build time Arguments, short circuit them to ENV Variables so they are available at run time also
@@ -13,23 +13,22 @@ ENV TGT_PLATFORM=$TARGET
 
 USER root
 
-## Install JFrog Plugins
-RUN fluent-gem install fluent-plugin-concat
-RUN fluent-gem install fluent-plugin-splunk-hec
-RUN fluent-gem install fluent-plugin-jfrog-siem
-RUN fluent-gem install fluent-plugin-jfrog-metrics
-RUN fluent-gem install fluent-plugin-jfrog-send-metrics
-
 # Install prerequisites
-RUN apt-get update && apt-get install -y curl
-CMD /bin/bash
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/*
+
+## Install JFrog Plugins
+RUN fluent-gem install fluent-plugin-concat && \
+    fluent-gem install fluent-plugin-splunk-hec && \
+    fluent-gem install fluent-plugin-jfrog-siem && \
+    fluent-gem install fluent-plugin-jfrog-metrics -v '~> 0.2.17' && \
+    fluent-gem install fluent-plugin-jfrog-send-metrics
 
 ## Download Config Files
-RUN if [ "$SRC_PLATFORM" = "JFRT" ] ; then echo "Downloading the fluentd config file for $SRC_PLATFORM and $TGT_PLATFORM "; curl https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.rt -o /opt/bitnami/fluentd/conf/fluentd.conf; else echo "Not Downloading"; fi
-RUN if [ "$SRC_PLATFORM" = "JFXRAY" ] ; then echo "Downloading the fluentd config file for $SRC_PLATFORM and $TGT_PLATFORM "; curl https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.xray -o /opt/bitnami/fluentd/conf/fluentd.conf; else echo "Not Downloading"; fi
+RUN if [ "$SRC_PLATFORM" = "JFRT" ] ; then curl -fsSL https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.rt -o /fluentd/etc/fluent.conf; fi
+RUN if [ "$SRC_PLATFORM" = "JFXRAY" ] ; then curl -fsSL https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.xray -o /fluentd/etc/fluent.conf; fi
 
-ENTRYPOINT if [ "$TGT_PLATFORM" = "SPLUNK" ] ; then cat /opt/bitnami/fluentd/conf/fluentd.conf; fluentd -v -c /opt/bitnami/fluentd/conf/fluentd.conf; fi
-
-USER 1001
+USER fluent
 
 STOPSIGNAL SIGTERM

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,5 +1,5 @@
-# Dockerfile for fluentd sidecar image with all the necessary plugins for our log analytic providers
-FROM reg.echohq.com/fluentd:1.19.2
+# Dockerfile for bitnami/fluentd sidecar image with all the necessary plugins for our log analytic providers
+FROM bitnami/fluentd:1.18.0
 LABEL maintainer="Partner Engineering <partner_support@jfrog.com>"
 
 ## Build time Arguments, short circuit them to ENV Variables so they are available at run time also
@@ -13,22 +13,23 @@ ENV TGT_PLATFORM=$TARGET
 
 USER root
 
-# Install prerequisites
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    rm -rf /var/lib/apt/lists/*
-
 ## Install JFrog Plugins
-RUN fluent-gem install fluent-plugin-concat && \
-    fluent-gem install fluent-plugin-splunk-hec && \
-    fluent-gem install fluent-plugin-jfrog-siem && \
-    fluent-gem install fluent-plugin-jfrog-metrics && \
-    fluent-gem install fluent-plugin-jfrog-send-metrics
+RUN fluent-gem install fluent-plugin-concat
+RUN fluent-gem install fluent-plugin-splunk-hec
+RUN fluent-gem install fluent-plugin-jfrog-siem
+RUN fluent-gem install fluent-plugin-jfrog-metrics
+RUN fluent-gem install fluent-plugin-jfrog-send-metrics
+
+# Install prerequisites
+RUN apt-get update && apt-get install -y curl
+CMD /bin/bash
 
 ## Download Config Files
-RUN if [ "$SRC_PLATFORM" = "JFRT" ] ; then curl -fsSL https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.rt -o /fluentd/etc/fluent.conf; fi
-RUN if [ "$SRC_PLATFORM" = "JFXRAY" ] ; then curl -fsSL https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.xray -o /fluentd/etc/fluent.conf; fi
+RUN if [ "$SRC_PLATFORM" = "JFRT" ] ; then echo "Downloading the fluentd config file for $SRC_PLATFORM and $TGT_PLATFORM "; curl https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.rt -o /opt/bitnami/fluentd/conf/fluentd.conf; else echo "Not Downloading"; fi
+RUN if [ "$SRC_PLATFORM" = "JFXRAY" ] ; then echo "Downloading the fluentd config file for $SRC_PLATFORM and $TGT_PLATFORM "; curl https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.xray -o /opt/bitnami/fluentd/conf/fluentd.conf; else echo "Not Downloading"; fi
 
-USER fluent
+ENTRYPOINT if [ "$TGT_PLATFORM" = "SPLUNK" ] ; then cat /opt/bitnami/fluentd/conf/fluentd.conf; fluentd -v -c /opt/bitnami/fluentd/conf/fluentd.conf; fi
+
+USER 1001
 
 STOPSIGNAL SIGTERM

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.19"
+      image: "releases-docker.jfrog.io/fluentd:4.20"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.19"
+      image: "releases-docker.jfrog.io/fluentd:4.20"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -19,7 +19,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.19"
+      image: "releases-docker.jfrog.io/fluentd:4.20"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
## Summary
Bumps the fluentd sidecar image from `4.19` to `4.20` across all Helm value files (artifactory, artifactory-ha, xray) + CHANGELOG. `4.20` is the Echo secure base image (CVE remediation, JOBS-2475). The Dockerfile change is in #91.

## Merge order (do not merge early)
Merge this **only after** `releases-docker.jfrog.io/fluentd:4.20` is built and promoted (JOBS-2478). These are public repos — merging before `4.20` is pullable causes ImagePullBackOff for customers deploying from master. See JOBS-2487.

## Changes
- `helm/artifactory-values.yaml`, `helm/artifactory-ha-values.yaml`, `helm/xray-values.yaml`: `fluentd:4.19` -> `fluentd:4.20`
- `CHANGELOG.md`: 4.20 release note