### PR TITLE
JOBS-2475: Use released fluentd:4.21 image directly (Dockerfile + Helm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All changes to the log analytics integration will be documented in this file.
 
+## [1.0.16] - June 2026
+
+* Fluentd sidecar image bumped to 4.21: now consumes the released image `releases-docker.jfrog.io/fluentd:4.21` directly (fluentd 1.19.2 on a hardened, CVE-refreshed base), remediating Critical/High CVEs in 4.19 (JOBS-2475)
+* `docker-build/Dockerfile` now builds `FROM releases-docker.jfrog.io/fluentd:4.21`, which already bundles curl and every required plugin (fluent-plugin-splunk-hec, -jfrog-siem, -jfrog-metrics, -jfrog-send-metrics, -concat), so the per-plugin `fluent-gem install` and `apt-get` steps were removed
+
 ## [1.0.15] - April 2026
 
 * Fix incorrect field name in access-security-audit log parsing: renamed `token_id` capture group to `trace_id` to match the actual log format documented at https://docs.jfrog.com/administration/docs/audit-trail-log (JOBS-2031)

--- a/README.md
+++ b/README.md
@@ -263,10 +263,13 @@ For Splunk as the observability platform, execute these commands to setup the do
    **JFROG_ADMIN_TOKEN**: Artifactory [Access Token](https://jfrog.com/help/r/how-to-generate-an-access-token-video/artifactory-creating-access-tokens-in-artifactory) for authentication
    **COMMON_JPD**: This flag should be set as true only for non-kubernetes installations or installations where JPD base URL is same to access both Artifactory and Xray (ex: https://sample_base_url/artifactory or https://sample_base_url/xray)
    **LOG_ENV**: Optional environment tag for categorizing logs and metrics (e.g., `staging`, `production`, `dev`). This tag will be added to all logs and metrics sent to Splunk as `env:<value>`
-3. Execute
+3. Execute the `docker run` command below.
+
+   > **⚠️ Before you run — log file permissions (uid 999):** the container runs as the non-root `fluent` user (uid `999`) and must **read** the mounted Artifactory logs and **write** `.pos` files into the mounted log directory. JFrog product logs are typically mode `640`, owned by the product user, which uid `999` cannot access by default — so the plain command **fails immediately** with `Errno::EACCES ... .pos` and the worker crash-loops, and **no logs or metrics are sent**. The quickest fix is to add `--user root` (shown below); for non-root alternatives see the **IMPORTANT** note right after this step.
 
    ```bash
-   docker run -it --name jfrog-fluentd-splunk-rt -v <path_to_folder_contains_log_dir>:/var/opt/jfrog/artifactory --env-file docker.env <image_name>
+   # --user root avoids the uid 999 log-permission issue described above (see the IMPORTANT note for non-root options)
+   docker run -it --user root --name jfrog-fluentd-splunk-rt -v <path_to_folder_contains_log_dir>:/var/opt/jfrog/artifactory --env-file docker.env <image_name>
    ```
 
    The <path_to_logs> should be an absolute path where the Jfrog Artifactory Logs folder resides, i.e for an Docker based Artifactory Installation,  ex: /var/opt/jfrog/artifactory/var/logs on the docker host.
@@ -274,8 +277,11 @@ For Splunk as the observability platform, execute these commands to setup the do
    Command example
 
    ```bash
-   docker run -it --name jfrog-fluentd-splunk-rt -v $JFROG_HOME/artifactory/var/:/var/opt/jfrog/artifactory --env-file docker.env jfrog/fluentd-splunk-rt
+   docker run -it --user root --name jfrog-fluentd-splunk-rt -v $JFROG_HOME/artifactory/var/:/var/opt/jfrog/artifactory --env-file docker.env jfrog/fluentd-splunk-rt
    ```
+
+> [!IMPORTANT]
+> The fluentd image runs as a non-root user (`fluent`, uid `999`). The container tails the Artifactory log files from the mounted directory and writes `.pos` (position) files next to them, so uid `999` must be able to **read** the mounted log files and **write** into the mounted log directory. JFrog product logs are typically owned by the product user (for example uid `1030`, directory mode `755`, files mode `640`), which uid `999` cannot access by default - fluentd then fails with `Errno::EACCES ... .pos` and the worker restarts in a loop. To avoid this, either run the container as root (`docker run --user root ...`), run it as the uid that owns the Artifactory logs (`--user <artifactory-uid>`), or make the mounted log directory readable and writable by uid `999`.
 
 ### Kubernetes Deployment with Helm
 

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,5 +1,5 @@
-# Dockerfile for bitnami/fluentd sidecar image with all the necessary plugins for our log analytic providers
-FROM bitnami/fluentd:1.18.0
+# Dockerfile for fluentd sidecar image with all the necessary plugins for our log analytic providers
+FROM releases-docker.jfrog.io/fluentd:4.21
 LABEL maintainer="Partner Engineering <partner_support@jfrog.com>"
 
 ## Build time Arguments, short circuit them to ENV Variables so they are available at run time also
@@ -13,23 +13,13 @@ ENV TGT_PLATFORM=$TARGET
 
 USER root
 
-## Install JFrog Plugins
-RUN fluent-gem install fluent-plugin-concat
-RUN fluent-gem install fluent-plugin-splunk-hec
-RUN fluent-gem install fluent-plugin-jfrog-siem
-RUN fluent-gem install fluent-plugin-jfrog-metrics
-RUN fluent-gem install fluent-plugin-jfrog-send-metrics
-
-# Install prerequisites
-RUN apt-get update && apt-get install -y curl
-CMD /bin/bash
-
 ## Download Config Files
-RUN if [ "$SRC_PLATFORM" = "JFRT" ] ; then echo "Downloading the fluentd config file for $SRC_PLATFORM and $TGT_PLATFORM "; curl https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.rt -o /opt/bitnami/fluentd/conf/fluentd.conf; else echo "Not Downloading"; fi
-RUN if [ "$SRC_PLATFORM" = "JFXRAY" ] ; then echo "Downloading the fluentd config file for $SRC_PLATFORM and $TGT_PLATFORM "; curl https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.xray -o /opt/bitnami/fluentd/conf/fluentd.conf; else echo "Not Downloading"; fi
+## The released image releases-docker.jfrog.io/fluentd:4.21 already ships fluentd 1.19.2, curl, and every
+## plugin this integration needs (fluent-plugin-splunk-hec, -jfrog-siem, -jfrog-metrics, -jfrog-send-metrics,
+## -concat, ...), so no fluent-gem install or apt-get step is required here.
+RUN if [ "$SRC_PLATFORM" = "JFRT" ] ; then curl -fsSL https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.rt -o /fluentd/etc/fluent.conf; fi
+RUN if [ "$SRC_PLATFORM" = "JFXRAY" ] ; then curl -fsSL https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.xray -o /fluentd/etc/fluent.conf; fi
 
-ENTRYPOINT if [ "$TGT_PLATFORM" = "SPLUNK" ] ; then cat /opt/bitnami/fluentd/conf/fluentd.conf; fluentd -v -c /opt/bitnami/fluentd/conf/fluentd.conf; fi
-
-USER 1001
+USER fluent
 
 STOPSIGNAL SIGTERM

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.19"
+      image: "releases-docker.jfrog.io/fluentd:4.21"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.19"
+      image: "releases-docker.jfrog.io/fluentd:4.21"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -19,7 +19,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.19"
+      image: "releases-docker.jfrog.io/fluentd:4.21"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
**Summary**
Consume the already-promoted public image `releases-docker.jfrog.io/fluentd:4.21` directly, instead of the private Echo base used on the superseded PRs.

- **docker-build/Dockerfile**: now `FROM releases-docker.jfrog.io/fluentd:4.21`; dropped the per-plugin `fluent-gem install` and the `apt-get install curl` steps. The released image already bundles fluentd 1.19.2, curl, and every required plugin, so "build-your-own-image" customers no longer need access to a private registry or a compiler.
- **helm/*-values.yaml**: bump the fluentd sidecar image `4.19 -> 4.21` (artifactory, artifactory-ha, xray).
- **README**: document the uid `999` log-dir permission requirement for the `docker run` path.
- **CHANGELOG**: add the 4.21 entry.

`releases-docker.jfrog.io/fluentd:4.21` is public (pullable with no auth) and is fluentd 1.19.2 on a hardened, CVE-refreshed base (remediates the Critical/High CVEs in 4.19).

Supersedes #91 (Echo-base Dockerfile) and #92 (Helm 4.20) — both will be closed in favor of this combined PR.

## Testing Done (released image, live E2E)
- Promoted image checked: uid 999, fluentd 1.19.2, curl present, all 12 plugins baked in, no gcc/cc/make.
- Built this provider image FROM releases-docker.jfrog.io/fluentd:4.21 (no plugin/apt installs); `fluentd --dry-run` loads the config cleanly.
- Ran the sidecar on the promoted image against a live Artifactory: **9,688 datapoints / 225 `jfrog.artifactory.*` metric names** confirmed in the Splunk `jfrog_metrics` index.

<img width="1718" height="1041" alt="Screenshot 2026-06-24 at 11 44 19 AM" src="https://github.com/user-attachments/assets/20f37767-5d06-4226-8612-011fb0b7ef23" />
