### PR TITLE
JOBS-2583 - Bump fluentd sidecar image to 4.22 (Echo 1.19.3, CVE-2026-55200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All changes to the log analytics integration will be documented in this file.
 
+## [1.0.17] - June 2026
+
+* Fluentd sidecar image bumped to 4.22: now consumes the released image `releases-docker.jfrog.io/fluentd:4.22` directly (fluentd 1.19.3 on the refreshed hardened Echo base), remediating the critical OS-package vulnerability CVE-2026-55200 in libssh2 (1.11.1-1+e1 -> 1.11.1-1+e2) carried by the 4.21 base image (JOBS-2583)
+* `docker-build/Dockerfile` now builds `FROM releases-docker.jfrog.io/fluentd:4.22`
+
 ## [1.0.16] - June 2026
 
 * Fluentd sidecar image bumped to 4.21: now consumes the released image `releases-docker.jfrog.io/fluentd:4.21` directly (fluentd 1.19.2 on a hardened, CVE-refreshed base), remediating Critical/High CVEs in 4.19 (JOBS-2475)

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for fluentd sidecar image with all the necessary plugins for our log analytic providers
-FROM releases-docker.jfrog.io/fluentd:4.21
+FROM releases-docker.jfrog.io/fluentd:4.22
 LABEL maintainer="Partner Engineering <partner_support@jfrog.com>"
 
 ## Build time Arguments, short circuit them to ENV Variables so they are available at run time also
@@ -14,7 +14,7 @@ ENV TGT_PLATFORM=$TARGET
 USER root
 
 ## Download Config Files
-## The released image releases-docker.jfrog.io/fluentd:4.21 already ships fluentd 1.19.2, curl, and every
+## The released image releases-docker.jfrog.io/fluentd:4.22 already ships fluentd 1.19.3, curl, and every
 ## plugin this integration needs (fluent-plugin-splunk-hec, -jfrog-siem, -jfrog-metrics, -jfrog-send-metrics,
 ## -concat, ...), so no fluent-gem install or apt-get step is required here.
 RUN if [ "$SRC_PLATFORM" = "JFRT" ] ; then curl -fsSL https://raw.githubusercontent.com/jfrog/log-analytics-splunk/master/fluent.conf.rt -o /fluentd/etc/fluent.conf; fi

--- a/helm/artifactory-ha-values.yaml
+++ b/helm/artifactory-ha-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.21"
+      image: "releases-docker.jfrog.io/fluentd:4.22"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/artifactory-values.yaml
+++ b/helm/artifactory-values.yaml
@@ -18,7 +18,7 @@ artifactory:
           name: artifactory-volume
   customSidecarContainers: |
     - name: "artifactory-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.21"
+      image: "releases-docker.jfrog.io/fluentd:4.22"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.artifactory.persistence.mountPath }}"

--- a/helm/xray-values.yaml
+++ b/helm/xray-values.yaml
@@ -19,7 +19,7 @@ common:
           name: data-volume
   customSidecarContainers: |
     - name: "xray-platform-fluentd-sidecar"
-      image: "releases-docker.jfrog.io/fluentd:4.21"
+      image: "releases-docker.jfrog.io/fluentd:4.22"
       imagePullPolicy: "IfNotPresent"
       volumeMounts:
         - mountPath: "{{ .Values.xray.persistence.mountPath }}"


### PR DESCRIPTION
## Summary
- Bump shared fluentd image `4.21` -> `4.22` in Helm values and docker-build Dockerfile.
- fluentd 1.19.3 on Echo base `1.19.3-20260627`; remediates CVE-2026-55200 (libssh2).

## Test plan
- [x] entplus `fluentd:4.22` image validated
<img width="706" height="1456" alt="splunk-rel422-search-authenticated" src="https://github.com/user-attachments/assets/14855e56-16cd-4730-a561-ab0f17daf4c0" />